### PR TITLE
add missing importFrom statements

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -56,9 +56,6 @@ exportClasses(mvabund, mvformula)
 exportMethods(meanvar.plot)
 
 import(Rcpp, MASS, graphics, methods, tweedie, statmod, parallel)
-importFrom(stats,dpois, ppois, qpois, rpois)
-importFrom(stats,dbinom, pbinom, qbinom, rbinom)
-importFrom(stats,dnbinom, pnbinom, qnbinom, rnbinom)
 
 S3method(extractAIC, manyglm)
 S3method(logLik, manyglm)
@@ -92,3 +89,22 @@ S3method(print, manyglm)
 S3method(print, mvformula)
 S3method(print, summary.manyglm)
 S3method(print, summary.manylm)
+
+importFrom("stats", "dpois", "ppois", "qpois", "rpois",
+           "dbinom", "pbinom", "qbinom", "rbinom",
+           "dnbinom", "pnbinom", "qnbinom", "rnbinom")
+importFrom("grDevices", "bmp", "dev.cur", "dev.interactive", "dev.list", "dev.off", "dev.set",
+           "jpeg", "palette", "pdf", "png", "postscript", "rainbow")
+importFrom("stats",
+           ".getXlevels", "as.formula", "coef", "contrasts",
+           "contrasts<-", "cov", "dcauchy", "deviance", "df.residual",
+           "dfbeta", "dnorm", "formula", "is.empty.model", "lm",
+           "loess.smooth", "logLik", "make.link", "model.frame",
+           "model.matrix", "model.offset", "model.response",
+           "model.weights", "na.exclude", "na.fail", "na.omit",
+           "na.pass", "naprint", "naresid", "pcauchy", "pf", "pnorm",
+           "poly", "predict", "predict.lm", "printCoefmat", "qcauchy",
+           "qnorm", "quantile", "reformulate", "residuals", "runif",
+           "sd", "symnum", "terms", "update", "var", "variable.names",
+           "weighted.residuals", "weights")
+importFrom("utils", "data", "flush.console", "installed.packages")


### PR DESCRIPTION
This fixes _most_ but not all of the issues raised in #2.  

The remainder now is 

```
* checking R code for possible problems ... NOTE
betaest: Error while checking: invalid 'envir' argument
manyany: Error while checking: invalid 'envir' argument
mu.update: Error while checking: invalid 'envir' argument
predict.manyglm: Error while checking: invalid 'envir' argument
* checking Rd files ... OK
``

which  I need to think about for a moment.  I did not immediately a set (or missing) environment.
```
