### PR TITLE
correct URL to mvabund downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## mvabund [![Build Status](https://travis-ci.org/aliceyiwang/mvabund.svg)](https://travis-ci.org/aliceyiwang/mvabund) [![License](http://img.shields.io/badge/license-LGPL%20%28%3E=%202.1%29-brightgreen.svg?style=flat)](http://www.gnu.org/licenses/gpl-2.0.html) [![CRAN](http://www.r-pkg.org/badges/version/mvabund)](http://cran.rstudio.com/package=mvabund) [![Downloads](http://cranlogs.r-pkg.org/badges/Mvabund?color=brightgreen)](http://www.r-pkg.org/pkg/mvabund)
+## mvabund [![Build Status](https://travis-ci.org/aliceyiwang/mvabund.svg)](https://travis-ci.org/aliceyiwang/mvabund) [![License](http://img.shields.io/badge/license-LGPL%20%28%3E=%202.1%29-brightgreen.svg?style=flat)](http://www.gnu.org/licenses/gpl-2.0.html) [![CRAN](http://www.r-pkg.org/badges/version/mvabund)](http://cran.rstudio.com/package=mvabund) [![Downloads](http://cranlogs.r-pkg.org/badges/mvabund?color=brightgreen)](http://www.r-pkg.org/pkg/mvabund)
 
 Statistical Methods for Analysing Multivariate Abundance Data
 


### PR DESCRIPTION
I had always wondered why the [README.md on GitHub](https://github.com/aliceyiwang/mvabund) (which is also shown at the top-level view of the repository) listed zero downloads for mvabund on CRAN.  This seemed impossible.

Turns out I had a type: mvabund was capitalized.  This PR corrects it to this URL:
http://cranlogs.r-pkg.org/badges/mvabund?color=brightgreen which currently lists 500+ downloads. Much better.

And while I have your attention, could I petition to be listed as contributor in DESCRIPTION and/or the README?  I won't be offended if you say no as I did not add analytical content -- but chiefly setup and plumbing.

PS Congrats on getting the new version onto CRAN!
