### PR TITLE
adding cloglog to anova/summary.manyglm

### DIFF
--- a/R/anova.manyglm.R
+++ b/R/anova.manyglm.R
@@ -67,11 +67,11 @@ anova.manyglm <- function(object, ..., resamp="pit.trap", test="LR", p.uni="none
     }
 
     # the following values need to be converted to integer types  
-    if (substr(object$family,1,1) == "p") familynum <- 1 
-    else if (substr(object$family,1,1) == "n") familynum <- 2
-    else if (substr(object$family,1,1)=="b") familynum <- 3
-    else stop("'family' not defined. See ?manyglm for currently available options.") 
-    
+    if (object$family == "poisson") { familynum <- 1; linkfun = 0 } 
+    else if (object$family == "negative.binomial") { familynum <- 2; linkfun = 0 }
+    else if (object$family == "binomial(link=logit)") { familynum <- 3; linkfun = 0 }
+    else if (object$family == "binomial(link=cloglog)") { familynum <- 3; linkfun = 1}
+    else stop("'family' not recognised. See ?manyglm for currently available options.") 
 
     if (object$theta.method == "ML") methodnum <- 0
     else if (object$theta.method == "Chi2") methodnum <- 1 

--- a/R/manyany.R
+++ b/R/manyany.R
@@ -120,7 +120,7 @@ manyany = function(fn, yMat, formula, data, family="negative.binomial", composit
         fam[[i.var]] = binomial()
         fam[[i.var]]$family = family[[i.var]]
       }
-      else if (family[[i.var]] == "binomial(link=cloglog)")
+      else if (family[[i.var]] == "binomial(link=cloglog)" || family[[i.var]] == "cloglog")
       {
         fam[[i.var]] = binomial("cloglog")
         fam[[i.var]]$family = family[[i.var]]

--- a/R/manyglm.R
+++ b/R/manyglm.R
@@ -48,8 +48,8 @@ if ( is.character(family) ) {
     }   
     else stop (paste("'family'", family, "not recognized"))
 }
-else stop ("Please specify a family function with a character string. manyglm supports the following members of the exponential family: 'gaussian', 'poisson', 'binomial', 'cloglog', 'negative.binomial', distributions.") 
-
+else stop("'family' not recognised. See ?manyglm for currently available options.") 
+  
 #stop ("Current manyglm only supports the following link function for binary binomial regression: 'logit', 'cloglog'.") 
 
 ret.x <- x

--- a/R/predict.traitglm.R
+++ b/R/predict.traitglm.R
@@ -61,6 +61,10 @@ predict.traitglm = function(object, newR=NULL, newQ=NULL, newL=NULL, type="respo
         object$family = binomial()
       else if (object$family == "binomial(link=cloglog)")
         object$family = binomial("cloglog")
+      else if (object$family == "poisson")
+        object$family = poisson()
+      else if (object$family == "gaussian")
+        object$family = gaussian()
       else
         family = get(family, mode = "function", envir = parent.frame())
     }

--- a/R/summary.manyglm.R
+++ b/R/summary.manyglm.R
@@ -52,11 +52,14 @@ summary.manyglm <- function(object, resamp="pit.trap", test="wald", p.uni="none"
 
     # the following values need to be converted to integer types  
 
-        if (substr(object$family,1,1) == "p") familynum <- 1 
-    else if (substr(object$family,1,1) == "n") familynum <- 2
-    else if (substr(object$family,1,1)=="b") familynum <- 3
-    else stop("'family' not defined. See ?manyglm for currently available options.") 
-    
+
+	  if (object$family == "poisson") { familynum <- 1; linkfun = 0 } 
+	  else if (object$family == "negative.binomial") { familynum <- 2; linkfun = 0 }
+	  else if (object$family == "binomial(link=logit)") { familynum <- 3; linkfun = 0 }
+	  else if (object$family == "binomial(link=cloglog)") { familynum <- 3; linkfun = 1}
+	  else stop("'family' not recognised. See ?manyglm for currently available options.") 
+	
+  
     if(object$theta.method == "ML") methodnum <- 0
     else if (object$theta.method == "Chi2") methodnum <- 1 
     else if (object$theta.method == "PHI") methodnum <- 2 


### PR DESCRIPTION
adding the cloglog option to the family argument used in anova.manyglm and summary.manyglm.  Note this does not seem to be working yet though! (cloglog seems to be treated like logit)
