### PR TITLE
Fixing data variable assignment in manylm and manyglm

### DIFF
--- a/R/manyglm.R
+++ b/R/manyglm.R
@@ -63,7 +63,11 @@ mf <- mf[c(1, m)]
 
 mf$drop.unused.levels <- FALSE
 mf[[1]] <- as.name("model.frame")
-data <- mf <- eval(mf, parent.frame())    # Obtain the model.frame. 
+mf <- eval(mf, parent.frame())    # Obtain the model.frame.
+
+if(missing(data)) # Only assign if not supplied by the user.
+  data <- mf
+
 mt <-  attr(mf, "terms")  # Obtain the model terms.
 offset <- as.vector(model.offset(mf))
 

--- a/R/manylm.R
+++ b/R/manylm.R
@@ -1,3 +1,4 @@
+mf[[1]] <- as.name("model.frame")
 ############################################################################
 # print.manylm prints the manylm object in a nice way                      #
 # so far this is identical with the print.lm method                        #
@@ -35,7 +36,11 @@ m  <- match(c("formula", "data", "subset", "weights", "na.action", "offset"), na
 mf <- mf[c(1, m)]
 mf$drop.unused.levels <- TRUE
 mf[[1]] <- as.name("model.frame")
-data <- mf <- eval(mf, parent.frame())    # Obtain the model.frame.
+mf <- eval(mf, parent.frame())    # Obtain the model.frame.
+
+if(missing(data)) # Only assign if not supplied by the user.
+  data <- mf
+
 #mf <- model.frame(formula)
 
 if (method == "model.frame") { 


### PR DESCRIPTION
The data variable is now only coerced to the model frame if it is not supplied by the user in manylm and manyglm. Previously it was coerced in every case, meaning that the predict() method would not work correctly.

Only three lines of code have been changed in each file, but due to issues with Git, it looks like hundreds of lines have been changed.