### PR TITLE
Fixes an issue with data variable assignment in manylm() and manyglm()

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -2,22 +2,22 @@
 # Generator token: 10BE3573-1514-4C36-9D1C-5A225CD40393
 
 RtoAnovaCpp <- function(rparam, Y, X, isXvarIn, bID) {
-    .Call('mvabund_RtoAnovaCpp', PACKAGE = 'mvabund', rparam, Y, X, isXvarIn, bID)
+    .Call('_mvabund_RtoAnovaCpp', PACKAGE = 'mvabund', rparam, Y, X, isXvarIn, bID)
 }
 
 RtoGlmAnova <- function(sparam, rparam, Y, X, O, isXvarIn, bID, lambda) {
-    .Call('mvabund_RtoGlmAnova', PACKAGE = 'mvabund', sparam, rparam, Y, X, O, isXvarIn, bID, lambda)
+    .Call('_mvabund_RtoGlmAnova', PACKAGE = 'mvabund', sparam, rparam, Y, X, O, isXvarIn, bID, lambda)
 }
 
 RtoGlm <- function(rparam, Y, X, O) {
-    .Call('mvabund_RtoGlm', PACKAGE = 'mvabund', rparam, Y, X, O)
+    .Call('_mvabund_RtoGlm', PACKAGE = 'mvabund', rparam, Y, X, O)
 }
 
 RtoGlmSmry <- function(sparam, rparam, Y, X, O, bID, lambda) {
-    .Call('mvabund_RtoGlmSmry', PACKAGE = 'mvabund', sparam, rparam, Y, X, O, bID, lambda)
+    .Call('_mvabund_RtoGlmSmry', PACKAGE = 'mvabund', sparam, rparam, Y, X, O, bID, lambda)
 }
 
 RtoSmryCpp <- function(rparam, Y, X, bID) {
-    .Call('mvabund_RtoSmryCpp', PACKAGE = 'mvabund', rparam, Y, X, bID)
+    .Call('_mvabund_RtoSmryCpp', PACKAGE = 'mvabund', rparam, Y, X, bID)
 }
 

--- a/R/manyglm.R
+++ b/R/manyglm.R
@@ -212,7 +212,7 @@ else {
     names(z$aic) <- labAbund
     names(z$iter) <- labAbund
 
-    z$data <- mf
+    z$data <- data
     z$stderr.coefficients <- sqrt(z$var.coefficients)
     dimnames(z$stderr.coefficients) <- list(colnames(X), labAbund)
     z$phi <- 1/z$theta

--- a/R/manyglm.R
+++ b/R/manyglm.R
@@ -63,7 +63,11 @@ mf <- mf[c(1, m)]
 
 mf$drop.unused.levels <- FALSE
 mf[[1]] <- as.name("model.frame")
-data <- mf <- eval(mf, parent.frame())    # Obtain the model.frame. 
+mf <- eval(mf, parent.frame())    # Obtain the model.frame.
+
+if(missing(data)) # Only coerce to model frame if not specified by the user.
+  data <- mf
+
 mt <-  attr(mf, "terms")  # Obtain the model terms.
 offset <- as.vector(model.offset(mf))
 

--- a/R/manylm.R
+++ b/R/manylm.R
@@ -35,8 +35,11 @@ m  <- match(c("formula", "data", "subset", "weights", "na.action", "offset"), na
 mf <- mf[c(1, m)]
 mf$drop.unused.levels <- TRUE
 mf[[1]] <- as.name("model.frame")
-data <- mf <- eval(mf, parent.frame())    # Obtain the model.frame.
+mf <- eval(mf, parent.frame())    # Obtain the model.frame.
 #mf <- model.frame(formula)
+
+if(missing(data)) # Only coerce to model frame if not specified by the user.
+  data <- mf
 
 if (method == "model.frame") { 
     return(mf)

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -9,7 +9,7 @@ using namespace Rcpp;
 
 // RtoAnovaCpp
 List RtoAnovaCpp(const List& rparam, RcppGSL::Matrix& Y, RcppGSL::Matrix& X, RcppGSL::Matrix& isXvarIn, Rcpp::Nullable<RcppGSL::Matrix>& bID);
-RcppExport SEXP mvabund_RtoAnovaCpp(SEXP rparamSEXP, SEXP YSEXP, SEXP XSEXP, SEXP isXvarInSEXP, SEXP bIDSEXP) {
+RcppExport SEXP _mvabund_RtoAnovaCpp(SEXP rparamSEXP, SEXP YSEXP, SEXP XSEXP, SEXP isXvarInSEXP, SEXP bIDSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -24,7 +24,7 @@ END_RCPP
 }
 // RtoGlmAnova
 List RtoGlmAnova(const List& sparam, const List& rparam, RcppGSL::Matrix& Y, RcppGSL::Matrix& X, RcppGSL::Matrix& O, RcppGSL::Matrix& isXvarIn, Rcpp::Nullable<RcppGSL::Matrix>& bID, RcppGSL::Vector& lambda);
-RcppExport SEXP mvabund_RtoGlmAnova(SEXP sparamSEXP, SEXP rparamSEXP, SEXP YSEXP, SEXP XSEXP, SEXP OSEXP, SEXP isXvarInSEXP, SEXP bIDSEXP, SEXP lambdaSEXP) {
+RcppExport SEXP _mvabund_RtoGlmAnova(SEXP sparamSEXP, SEXP rparamSEXP, SEXP YSEXP, SEXP XSEXP, SEXP OSEXP, SEXP isXvarInSEXP, SEXP bIDSEXP, SEXP lambdaSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -42,7 +42,7 @@ END_RCPP
 }
 // RtoGlm
 List RtoGlm(const List& rparam, RcppGSL::Matrix& Y, RcppGSL::Matrix& X, RcppGSL::Matrix& O);
-RcppExport SEXP mvabund_RtoGlm(SEXP rparamSEXP, SEXP YSEXP, SEXP XSEXP, SEXP OSEXP) {
+RcppExport SEXP _mvabund_RtoGlm(SEXP rparamSEXP, SEXP YSEXP, SEXP XSEXP, SEXP OSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -56,7 +56,7 @@ END_RCPP
 }
 // RtoGlmSmry
 List RtoGlmSmry(const List& sparam, const List& rparam, RcppGSL::Matrix& Y, RcppGSL::Matrix& X, RcppGSL::Matrix& O, Rcpp::Nullable<RcppGSL::Matrix>& bID, RcppGSL::Vector& lambda);
-RcppExport SEXP mvabund_RtoGlmSmry(SEXP sparamSEXP, SEXP rparamSEXP, SEXP YSEXP, SEXP XSEXP, SEXP OSEXP, SEXP bIDSEXP, SEXP lambdaSEXP) {
+RcppExport SEXP _mvabund_RtoGlmSmry(SEXP sparamSEXP, SEXP rparamSEXP, SEXP YSEXP, SEXP XSEXP, SEXP OSEXP, SEXP bIDSEXP, SEXP lambdaSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -73,7 +73,7 @@ END_RCPP
 }
 // RtoSmryCpp
 List RtoSmryCpp(const List& rparam, RcppGSL::Matrix& Y, RcppGSL::Matrix& X, Rcpp::Nullable<RcppGSL::Matrix>& bID);
-RcppExport SEXP mvabund_RtoSmryCpp(SEXP rparamSEXP, SEXP YSEXP, SEXP XSEXP, SEXP bIDSEXP) {
+RcppExport SEXP _mvabund_RtoSmryCpp(SEXP rparamSEXP, SEXP YSEXP, SEXP XSEXP, SEXP bIDSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -84,4 +84,18 @@ BEGIN_RCPP
     rcpp_result_gen = Rcpp::wrap(RtoSmryCpp(rparam, Y, X, bID));
     return rcpp_result_gen;
 END_RCPP
+}
+
+static const R_CallMethodDef CallEntries[] = {
+    {"_mvabund_RtoAnovaCpp", (DL_FUNC) &_mvabund_RtoAnovaCpp, 5},
+    {"_mvabund_RtoGlmAnova", (DL_FUNC) &_mvabund_RtoGlmAnova, 8},
+    {"_mvabund_RtoGlm", (DL_FUNC) &_mvabund_RtoGlm, 4},
+    {"_mvabund_RtoGlmSmry", (DL_FUNC) &_mvabund_RtoGlmSmry, 7},
+    {"_mvabund_RtoSmryCpp", (DL_FUNC) &_mvabund_RtoSmryCpp, 4},
+    {NULL, NULL, 0}
+};
+
+RcppExport void R_init_mvabund(DllInfo *dll) {
+    R_registerRoutines(dll, NULL, CallEntries, NULL, NULL);
+    R_useDynamicSymbols(dll, FALSE);
 }


### PR DESCRIPTION
The data variable in manylm() and manyglm() should only be coerced to the model frame if it is NOT specified by the user. Otherwise when using formulas, predict.manyglm and predict.manylm will give an error, i.e this commit means that the following does not return an error and functions correctly:

data(spider)

Y = mvabund(spider$abund)
x = data.frame(spider$x[ , 1:2])
x[ , 2] = 1:nrow(x)
colnames(x)[2] = "off"

manymod = manyglm(Y ~ soil.dry + offset(log(off)), data = x)
newdat = data.frame(soil.dry = c(1, 2, 3), off = c(1, 2, 3))

predict(manymod, newdata = newdat) #returns an error