### PR TITLE
Some minor header include reorganization

### DIFF
--- a/src/Makevars
+++ b/src/Makevars
@@ -1,10 +1,13 @@
-## Use the R_HOME indirection to support installations of multiple R version
-## And RcppGSL can tell us where GSL is installed 
 
+## We want C++11
 CXX_STD = CXX11
 
-## header files from our package and from the GSL
-PKG_CPPFLAGS = -I. -I../inst/include `$(R_HOME)/bin/Rscript -e "RcppGSL:::CFlags()"`
+## Header files from our package, RcppGSL comes in via LinkingTo: in DESCRIPTIPM
+PKG_CPPFLAGS = -I. -I../inst/include
 
-## library from the GSL
+## If we want LTO (for testing or optimization)
+#PKG_CXXFLAGS = -flto
+
+## Use the R_HOME indirection to support installations of multiple R version
+## And RcppGSL can tell us where GSL is installed so we get the libraries for linking
 PKG_LIBS = `$(R_HOME)/bin/Rscript -e "RcppGSL:::LdFlags()"`

--- a/src/Rinterface.cpp
+++ b/src/Rinterface.cpp
@@ -3,13 +3,12 @@
 // Author: Yi Wang (yi dot wang at unsw dot edu dot au)
 // Last modified: 20-April-2010
 //
-// Rcpp/RcppGSL changes by Dirk Eddelbuettel, July - August 2015
+// Rcpp/RcppGSL changes by Dirk Eddelbuettel, July - August 2015, Feb 2020
 
 #include "mvabund_types.h"
-#include <RcppGSL.h>
-extern "C" {
 #include "resampTest.h"
-#include "time.h"
+extern "C" {
+  #include "time.h"
 }
 
 using namespace Rcpp;
@@ -36,7 +35,7 @@ List RtoAnovaCpp(const List &rparam, RcppGSL::Matrix &Y, RcppGSL::Matrix &X,
   mm.punit = as<unsigned int>(rparam["punit"]);
   mm.rsquare = as<unsigned int>(rparam["rsquare"]);
 
-  unsigned int nRows = Y.nrow();
+  //unsigned int nRows = Y.nrow();
   unsigned int nModels = isXvarIn.nrow();
 
   // initialize anova class
@@ -359,7 +358,7 @@ List RtoSmryCpp(const List &rparam, RcppGSL::Matrix &Y, RcppGSL::Matrix &X,
   mm.punit = as<unsigned int>(rparam["punit"]);
   mm.rsquare = as<unsigned int>(rparam["rsquare"]);
 
-  unsigned int nRows = Y.nrow();
+  //unsigned int nRows = Y.nrow();
   unsigned int nVars = Y.ncol();
   unsigned int nParam = X.ncol();
 

--- a/src/resampTest.h
+++ b/src/resampTest.h
@@ -5,11 +5,12 @@
 #ifndef _RESAMPTEST_H
 #define _RESAMPTEST_H
 
-#include "R.h"
-#include "Rmath.h"
+// include R headers, but under 'strict' definitions
+#define STRICT_R_HEADERS
+#include <RcppGSL.h>
+
 #define printf Rprintf
 
-#define STRICT_R_HEADERS
 /*
 #define MATHLIB_STANDALONE
 #include "/usr/local/R/2.13/lib64/R/include/Rmath.h"


### PR DESCRIPTION
This should help under different compilation schemes as for example with `-flto` as headers are now included more consistently.