### PR TITLE
Add GitHub Actions CI via run.sh from r-ci, add badge to README.md

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -2,3 +2,4 @@
 ^.*\.Rproj$
 ^\.Rproj\.user$
 ^Makefile$
+^\.github

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,40 @@
+# Run CI for R using https://eddelbuettel.github.io/r-ci/
+
+name: ci
+
+on:
+  push:
+  pull_request:
+
+env:
+  USE_BSPM: "true"
+  _R_CHECK_FORCE_SUGGESTS_: "false"
+
+jobs:
+  ci:
+    strategy:
+      matrix:
+        include:
+          #- {os: macOS-latest}
+          - {os: ubuntu-latest}
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Bootstrap
+        run: |
+          curl -OLs https://eddelbuettel.github.io/r-ci/run.sh
+          chmod 0755 run.sh
+          ./run.sh bootstrap
+
+      - name: Dependencies
+        run: ./run.sh install_deps
+
+      - name: Test
+        run: ./run.sh run_tests
+
+      #- name: Coverage
+      #  if: ${{ matrix.os == 'ubuntu-latest' }}
+      #  run: ./run.sh coverage

--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
-## mvabund [![Build Status](https://travis-ci.org/aliceyiwang/mvabund.svg)](https://travis-ci.org/aliceyiwang/mvabund) [![License](http://img.shields.io/badge/license-LGPL%20%28%3E=%202.1%29-brightgreen.svg?style=flat)](http://www.gnu.org/licenses/gpl-2.0.html) [![CRAN](http://www.r-pkg.org/badges/version/mvabund)](https://CRAN.R-project.org/package=mvabund) [![Downloads](http://cranlogs.r-pkg.org/badges/mvabund?color=brightgreen)](https://www.r-pkg.org/pkg/mvabund)
-=======
+## mvabund: Statistical Methods for Analysing Multivariate Abundance Data
 
-Statistical Methods for Analysing Multivariate Abundance Data
+[![Build Status](https://travis-ci.org/aliceyiwang/mvabund.svg)](https://travis-ci.org/aliceyiwang/mvabund) 
+[![CI](https://github.com/aliceyiwang/mvabund/workflows/ci/badge.svg)](https://github.com/aliceyiwang/mvabund/actions?query=workflow%3Aci)
+[![License](http://img.shields.io/badge/license-LGPL%20%28%3E=%202.1%29-brightgreen.svg?style=flat)](http://www.gnu.org/licenses/gpl-2.0.html) 
+[![CRAN](http://www.r-pkg.org/badges/version/mvabund)](https://CRAN.R-project.org/package=mvabund) 
+[![Downloads](http://cranlogs.r-pkg.org/badges/mvabund?color=brightgreen)](https://www.r-pkg.org/pkg/mvabund)
 
 ### Authors
 


### PR DESCRIPTION
This adds my standard `ci.yaml` using `run.sh` from [r-ci](https://eddelbuettel.github.io/r-ci/) which (a priori) portable across CI backends (but the GSL dependency we have here bites us a little).

See https://github.com/aliceyiwang/mvabund/actions for the first three runs.  

I was a little ambitious and tried to also run macOS which works for _some_ packages, but not all (and I generally do not bother with most of own packages). The macOS setup behind GitHub Actions is a bit more "volatile" than the Linux variant, plus we have the added need of the GSL dependency which we know we get taken care of on the Linux + Ubuntu side -- but sadly not so much for macOS.  

The PR does not remove support for Travis which continues unaltered. We could use the same `run.sh` there too -- but Travis is on a bit off a downward slope among Open Source / R users as they try _very_ hard to monetize their service.